### PR TITLE
Track request methods

### DIFF
--- a/telemetry-agent/pom.xml
+++ b/telemetry-agent/pom.xml
@@ -79,6 +79,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
+                    <forceCreation>true</forceCreation>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/telemetry-agent/src/main/resources/com/yammer/telemetry/agent/handlers/HttpClient_execute.javassist
+++ b/telemetry-agent/src/main/resources/com/yammer/telemetry/agent/handlers/HttpClient_execute.javassist
@@ -7,7 +7,9 @@
     HttpUriRequest uriRequest = %HTTP_REQUEST_URI_PARAM%;
 
     // Start the span.
-    Span span = Span.startSpan(request.getRequestLine().getUri());
+    final String name = String.format("%s %s", new Object[] {request.getRequestLine().getMethod(), request.getRequestLine().getUri()});
+    Span span = Span.startSpan(name);
+    //Span span = Span.startSpan(request.getRequestLine().getUri());
 
     // Set the request headers to link up this client request with the corresponding
     // service request.

--- a/telemetry-agent/src/main/resources/com/yammer/telemetry/agent/handlers/HttpServlet_service.javassist
+++ b/telemetry-agent/src/main/resources/com/yammer/telemetry/agent/handlers/HttpServlet_service.javassist
@@ -3,12 +3,13 @@
 
     final String traceId = $1.getHeader(HttpHeaderNames.TRACE_ID);
     final String spanId = $1.getHeader(HttpHeaderNames.SPAN_ID);
+    final String name = String.format("%s %s", new Object[] {$1.getMethod(), $1.getRequestURL()});
     if (traceId != null && spanId != null) {
         BigInteger traceIdLong = new BigInteger(traceId);
         BigInteger spanIdLong = new BigInteger(spanId);
-        span = Span.attachSpan(traceIdLong, spanIdLong, $1.getRequestURL().toString());
+        span = Span.attachSpan(traceIdLong, spanIdLong, name);
     } else {
-        span = Span.startTrace($1.getRequestURL().toString());
+        span = Span.startTrace(name);
     }
 
     try {

--- a/telemetry-agent/src/test/java/com/yammer/telemetry/agent/test/SimpleServlet.java
+++ b/telemetry-agent/src/test/java/com/yammer/telemetry/agent/test/SimpleServlet.java
@@ -1,5 +1,7 @@
 package com.yammer.telemetry.agent.test;
 
+import org.apache.http.StatusLine;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -16,5 +18,10 @@ public class SimpleServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.getWriter().print("foof");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(201);
     }
 }

--- a/telemetry-example/pom.xml
+++ b/telemetry-example/pom.xml
@@ -50,6 +50,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
+                    <forceCreation>true</forceCreation>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/telemetry-example/telemetry.yml
+++ b/telemetry-example/telemetry.yml
@@ -5,6 +5,8 @@ instruments:
 - metrics
 - executors
 
+sampler: off
+
 sinks:
   log:
     enabled: true


### PR DESCRIPTION
Modify the HttpServlet and HttpClient instrumentations to record the request method in the span name.

The new name will be of the format "<HttpMethod> <HttpRequestUri>".
