### PR TITLE
Expose annotation beneath span, simplify SpanSink interface.

### DIFF
--- a/telemetry-agent/src/test/java/com/yammer/telemetry/agent/handlers/HttpServletClassHandlerTest.java
+++ b/telemetry-agent/src/test/java/com/yammer/telemetry/agent/handlers/HttpServletClassHandlerTest.java
@@ -56,7 +56,7 @@ public class HttpServletClassHandlerTest {
     }
 
     @Test
-    public void testRecordsSpans() throws Exception {
+    public void testRunTransformedTests() throws Exception {
         runTransformed(TransformedTests.class, handler);
     }
 

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/AsynchronousSpanSink.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/AsynchronousSpanSink.java
@@ -1,6 +1,5 @@
 package com.yammer.telemetry.tracing;
 
-import java.math.BigInteger;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -16,12 +15,6 @@ public class AsynchronousSpanSink implements SpanSink {
     @Override
     public void record(SpanData spanData) {
         Runnable job = jobFactory.createJob(spanData);
-        executor.execute(job);
-    }
-
-    @Override
-    public void recordAnnotation(BigInteger traceId, BigInteger spanId, AnnotationData annotationData) {
-        Runnable job = jobFactory.createJob(traceId, spanId, annotationData);
         executor.execute(job);
     }
 
@@ -46,6 +39,5 @@ public class AsynchronousSpanSink implements SpanSink {
 
     public static interface JobFactory {
         Runnable createJob(SpanData data);
-        Runnable createJob(BigInteger traceId, BigInteger spanId, AnnotationData data);
     }
 }

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/InMemorySpanSinkSource.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/InMemorySpanSinkSource.java
@@ -30,17 +30,6 @@ public class InMemorySpanSinkSource implements SpanSink {
         }
     }
 
-    @Override
-    public void recordAnnotation(BigInteger traceId, BigInteger spanId, AnnotationData annotationData) {
-        final Trace newTrace = new Trace(traceId);
-        newTrace.addAnnotation(spanId, annotationData);
-
-        final Trace trace = traces.putIfAbsent(traceId, newTrace);
-        if (trace != null) {
-            trace.addAnnotation(spanId, annotationData);
-        }
-    }
-
     public int recordedTraceCount() {
         return traces.size();
     }

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/LoggingSpanSinkBuilder.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/LoggingSpanSinkBuilder.java
@@ -4,12 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.collect.ImmutableList;
 
 import java.io.*;
-import java.math.BigInteger;
 import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
@@ -63,16 +60,6 @@ public class LoggingSpanSinkBuilder {
         @Override
         public Runnable createJob(SpanData data) {
             return genericJob(data);
-        }
-
-        @Override
-        public Runnable createJob(BigInteger traceId, BigInteger spanId, AnnotationData data) {
-            HashMap<String, Object> map = new HashMap<>();
-            map.put("trace_id", traceId);
-            map.put("span_id", spanId);
-            map.put("annotations", ImmutableList.of(data));
-
-            return genericJob(map);
         }
 
         private Runnable genericJob(Object object) {

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/Span.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/Span.java
@@ -160,14 +160,6 @@ public class Span implements AutoCloseable, SpanData {
         } else {
             throw new IllegalStateException("Span.end() from a detached span.");
         }
-
-        if (traceLevel == TraceLevel.ON) {
-            for (SpanSink sink : SpanSinkRegistry.getSpanSinks()) {
-                for (AnnotationData annotation : annotations) {
-                    sink.recordAnnotation(getTraceId(), getSpanId(), annotation);
-                }
-            }
-        }
     }
 
     /**
@@ -220,6 +212,11 @@ public class Span implements AutoCloseable, SpanData {
 
     public long getDuration() {
         return duration;
+    }
+
+    @Override
+    public List<AnnotationData> getAnnotations() {
+        return annotations;
     }
 
     public static Sampling getSampler() {

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/SpanData.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/SpanData.java
@@ -3,7 +3,9 @@ package com.yammer.telemetry.tracing;
 import com.google.common.base.Optional;
 
 import java.math.BigInteger;
+import java.util.List;
 
+@SuppressWarnings("UnusedDeclaration")
 public interface SpanData {
     BigInteger getTraceId();
 
@@ -18,4 +20,6 @@ public interface SpanData {
     long getStartTime();
 
     long getDuration();
+
+    List<AnnotationData> getAnnotations();
 }

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/SpanSink.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/SpanSink.java
@@ -1,10 +1,5 @@
 package com.yammer.telemetry.tracing;
 
-import java.math.BigInteger;
-
 public interface SpanSink {
-
     void record(SpanData spanData);
-
-    void recordAnnotation(BigInteger traceId, BigInteger spanId, AnnotationData annotationData);
 }

--- a/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/Trace.java
+++ b/telemetry-lib/src/main/java/com/yammer/telemetry/tracing/Trace.java
@@ -56,6 +56,10 @@ public class Trace {
                 siblings.add(spanData);
             }
         }
+
+        for (AnnotationData annotation : spanData.getAnnotations()) {
+            addAnnotation(spanData.getSpanId(), annotation);
+        }
     }
 
     public void addAnnotation(BigInteger spanId, AnnotationData data) {

--- a/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/AsynchronousSpanSinkTest.java
+++ b/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/AsynchronousSpanSinkTest.java
@@ -1,9 +1,11 @@
 package com.yammer.telemetry.tracing;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,28 +39,6 @@ public class AsynchronousSpanSinkTest {
     }
 
     @Test
-    public void testSubmitsExpectedAnnotationTasksToExecutor() {
-        ExecutorService executor = mock(ExecutorService.class);
-
-        AsynchronousSpanSink.JobFactory jobFactory = mock(AsynchronousSpanSink.JobFactory.class);
-        SpanSink sink = new AsynchronousSpanSink(executor, jobFactory);
-
-        AnnotationData annotationData = new FakeAnnotationData();
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-            }
-        };
-
-        when(jobFactory.createJob(BigInteger.ONE, BigInteger.TEN, annotationData)).thenReturn(runnable);
-
-        sink.recordAnnotation(BigInteger.ONE, BigInteger.TEN, annotationData);
-
-        verify(jobFactory).createJob(BigInteger.ONE, BigInteger.TEN, annotationData);
-        verify(executor).execute(eq(runnable));
-    }
-
-    @Test
     public void testShutdownWhenLongRunningTask() throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -79,10 +59,6 @@ public class AsynchronousSpanSinkTest {
                 };
             }
 
-            @Override
-            public Runnable createJob(BigInteger traceId, BigInteger spanId, AnnotationData data) {
-                throw new UnsupportedOperationException();
-            }
         });
 
         sink.record(new FakeSpanData());
@@ -114,10 +90,6 @@ public class AsynchronousSpanSinkTest {
                 };
             }
 
-            @Override
-            public Runnable createJob(BigInteger traceId, BigInteger spanId, AnnotationData data) {
-                throw new UnsupportedOperationException();
-            }
         });
 
         sink.record(new FakeSpanData());
@@ -166,24 +138,10 @@ public class AsynchronousSpanSinkTest {
         public long getDuration() {
             return 100;
         }
-    }
-
-    private static class FakeAnnotationData implements AnnotationData {
-        private long loggedAt = System.nanoTime();
 
         @Override
-        public long getLoggedAt() {
-            return loggedAt;
-        }
-
-        @Override
-        public String getName() {
-            return "A Name";
-        }
-
-        @Override
-        public String getMessage() {
-            return "A Message";
+        public List<AnnotationData> getAnnotations() {
+            return ImmutableList.of();
         }
     }
 }

--- a/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/LoggingSpanSinkBuilderTest.java
+++ b/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/LoggingSpanSinkBuilderTest.java
@@ -5,18 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import java.io.StringWriter;
 import java.math.BigInteger;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class LoggingSpanSinkBuilderTest {
 
@@ -27,7 +24,82 @@ public class LoggingSpanSinkBuilderTest {
         StringWriter writer = new StringWriter();
         AsynchronousSpanSink spanSink = new LoggingSpanSinkBuilder().withWriter(writer).build();
 
+        final long theStartTime = System.nanoTime();
         SpanData spanData = new SpanData() {
+            private long startTime = theStartTime;
+
+            @Override
+            public BigInteger getTraceId() {
+                return BigInteger.ONE;
+            }
+
+            @Override
+            public BigInteger getSpanId() {
+                return BigInteger.TEN;
+            }
+
+            @Override
+            public Optional<BigInteger> getParentSpanId() {
+                return Optional.absent();
+            }
+
+            @Override
+            public String getName() {
+                return "Some Name";
+            }
+
+            @Override
+            public String getHost() {
+                return "SomeHost";
+            }
+
+            @Override
+            public long getStartTime() {
+                return startTime;
+            }
+
+            @Override
+            public long getDuration() {
+                return 100;
+            }
+
+            @Override
+            public List<AnnotationData> getAnnotations() {
+                return ImmutableList.<AnnotationData>of(new AnnotationData() {
+                    @Override
+                    public long getLoggedAt() {
+                        return theStartTime + 10;
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "Annotation";
+                    }
+
+                    @Override
+                    public String getMessage() {
+                        return "Annotation Message";
+                    }
+                });
+            }
+        };
+
+        spanSink.record(spanData);
+
+        assertEquals(0, spanSink.shutdown(100, TimeUnit.MILLISECONDS));
+
+        String output = writer.toString();
+        assertEquals(objectMapper.writeValueAsString(spanData) + "\n", output);
+        assertFalse(output.contains("serviceName"));
+        assertFalse(output.contains("serviceHost"));
+    }
+
+    @Test
+    public void testWritingInvalidObject() throws Exception {
+        StringWriter writer = new StringWriter();
+        AsynchronousSpanSink spanSink = new LoggingSpanSinkBuilder().withWriter(writer).build();
+
+        @SuppressWarnings("UnusedDeclaration") SpanData spanData = new SpanData() {
             private long startTime = System.nanoTime();
 
             @Override
@@ -64,73 +136,18 @@ public class LoggingSpanSinkBuilderTest {
             public long getDuration() {
                 return 100;
             }
-        };
-
-        spanSink.record(spanData);
-
-        assertEquals(0, spanSink.shutdown(100, TimeUnit.MILLISECONDS));
-
-        String output = writer.toString();
-        assertEquals(objectMapper.writeValueAsString(spanData) + "\n", output);
-        assertFalse(output.contains("serviceName"));
-        assertFalse(output.contains("serviceHost"));
-    }
-
-    @Test
-    public void testLogsAnnotation() throws Exception {
-        StringWriter writer = new StringWriter();
-        AsynchronousSpanSink spanSink = new LoggingSpanSinkBuilder().withWriter(writer).build();
-
-        AnnotationData annotationData = new Annotation(System.nanoTime(), "The Name", "The Message");
-
-        spanSink.recordAnnotation(BigInteger.ONE, BigInteger.TEN, annotationData);
-
-        assertEquals(0, spanSink.shutdown(100, TimeUnit.MILLISECONDS));
-
-        HashMap read = objectMapper.readValue(writer.toString(), HashMap.class);
-
-        assertEquals(10, read.get("span_id"));
-        assertEquals(1, read.get("trace_id"));
-
-        List annotations = (List) read.get("annotations");
-        assertEquals(1, annotations.size());
-
-        Map annotationMap = (Map)annotations.get(0);
-        assertEquals(annotationData.getLoggedAt(), annotationMap.get("logged_at"));
-        assertEquals(annotationData.getName(), annotationMap.get("name"));
-        assertEquals(annotationData.getMessage(), annotationMap.get("message"));
-    }
-
-    @Test
-    public void testWritingInvalidObject() throws Exception {
-        StringWriter writer = new StringWriter();
-        AsynchronousSpanSink spanSink = new LoggingSpanSinkBuilder().withWriter(writer).build();
-
-        AnnotationData annotationData = new AnnotationData() {
-            private long loggedAt = System.nanoTime();
-            private Foo otherThing = new Foo();
 
             @Override
-            public long getLoggedAt() {
-                return loggedAt;
-            }
-
-            @Override
-            public String getName() {
-                return "The Name";
-            }
-
-            @Override
-            public String getMessage() {
-                return "The Message";
+            public List<AnnotationData> getAnnotations() {
+                return ImmutableList.of();
             }
 
             public Foo getFoo() {
-                return otherThing;
+                return new Foo();
             }
         };
 
-        spanSink.recordAnnotation(BigInteger.ONE, BigInteger.TEN, annotationData);
+        spanSink.record(spanData);
 
         assertEquals(0, spanSink.shutdown(100, TimeUnit.MILLISECONDS));
 

--- a/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/SpanUsageTest.java
+++ b/telemetry-lib/src/test/java/com/yammer/telemetry/tracing/SpanUsageTest.java
@@ -228,6 +228,19 @@ public class SpanUsageTest {
         assertNull(trace);
     }
 
+    @Test
+    public void testAnnotationRecordedAfterSpanEnded() {
+        Span.setSampler(Sampling.ON);
+        Span trace = Span.startTrace("trace");
+        trace.addAnnotation("During");
+        trace.end();
+        trace.addAnnotation("After");
+
+        assertEquals(1, sink.recordedTraceCount());
+        Trace theTrace = sink.getTrace(trace.getTraceId());
+        System.out.println(theTrace);
+    }
+
     private Trace testSpan(Strategy strategy) {
         final AtomicReference<BigInteger> traceId = new AtomicReference<>();
         final AtomicReference<BigInteger> spanId = new AtomicReference<>();


### PR DESCRIPTION
This allows logging to capture the span and annotations at the same time.
